### PR TITLE
Added cookbook name to jetbrains x11

### DIFF
--- a/resources/jetbrains_toolbox.rb
+++ b/resources/jetbrains_toolbox.rb
@@ -50,6 +50,7 @@ action :install do
 
   template 'install jetrbains toolbox run on boot' do
     source 'jetbrains_toolbox/xsession.erb'
+    cookbook 'codenamephp_dev'
     path '/etc/X11/Xsession.d/100-jetbrains-toolbox'
     owner 'root'
     group 'root'


### PR DESCRIPTION
The tempalte for the x11 session should always come from my cookbook and has to be set since it would default to the calling cookbook where the template does not exist