### PR TITLE
Added libgbm1 and libxcb-dri3-0 since they are needed to run VSCode

### DIFF
--- a/resources/vscode.rb
+++ b/resources/vscode.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-deprecated 'The codenamephp_dev_vscode resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major relase.'
+deprecated 'The codenamephp_dev_vscode resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major release.'
 
 property :users_extensions, Hash, default: {}, description: 'A hash where the username is the key and the value is an array with extension names as string for that user'
 

--- a/resources/vscode.rb
+++ b/resources/vscode.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+deprecated 'The codenamephp_dev_vscode resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major relase.'
+
 property :users_extensions, Hash, default: {}, description: 'A hash where the username is the key and the value is an array with extension names as string for that user'
 
 action :install do
-  package %w[libx11-xcb1 libasound2]
+  package %w[libx11-xcb1 libasound2 libgbm1 libxcb-dri3-0]
 
   sc_vscode_installer 'install vscode'
 

--- a/resources/vscode_extensions.rb
+++ b/resources/vscode_extensions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-deprecated 'The codenamephp_dev_vscode_extensions resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major relase.'
+deprecated 'The codenamephp_dev_vscode_extensions resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major release.'
 
 property :users_extensions, Hash, required: true, description: 'A hash where the username is the key and the value is an array with extension names as string for that user'
 

--- a/resources/vscode_extensions.rb
+++ b/resources/vscode_extensions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+deprecated 'The codenamephp_dev_vscode_extensions resource has been deprecated and will be moved to its own dedicated cookbook. This resource will be removed with the next major relase.'
+
 property :users_extensions, Hash, required: true, description: 'A hash where the username is the key and the value is an array with extension names as string for that user'
 
 action :install do

--- a/spec/unit/resources/vscode_spec.rb
+++ b/spec/unit/resources/vscode_spec.rb
@@ -17,7 +17,7 @@ describe 'codenamephp_dev_vscode' do
     end
 
     it 'installs dependencies' do
-      expect(chef_run).to install_package(%w[libx11-xcb1 libasound2])
+      expect(chef_run).to install_package(%w[libx11-xcb1 libasound2 libgbm1 libxcb-dri3-0])
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
The packages were added to the already existing package install. Without them the extension install fails. My guess is that they are usually added when installing any X-GUI but since VSCode might be installed before that it's a good idea to install them manually.